### PR TITLE
move code checkout to start in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
       - name: Get pull request that was merged (pushed commit) into base default (main) branch
         uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
@@ -61,13 +67,6 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-
-      - name: Checkout code
-        if: ${{ steps.bump-semver.outputs.new_version != null && steps.import-gpg.outputs.keyid != null }}
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup git credentials
         if: ${{ steps.bump-semver.outputs.new_version != null && steps.import-gpg.outputs.keyid != null }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT_TOKEN }}
 
       - name: Get semver level from pull request labels
         # Continue only with pull request (title not null)
@@ -35,7 +35,6 @@ jobs:
         uses: actions-ecosystem/action-release-label@v1
         id: release-label
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           label_prefix: ''
           labels: ${{ steps.get-merged-pull-request.outputs.labels }}
 


### PR DESCRIPTION
Since the error says that mounted workspace folder is not a git repository make repository fetch at the start of the workflow.